### PR TITLE
Use wercker/rvm box with ruby 2.2.5

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -2,20 +2,20 @@ box: wercker/rvm
 build:
   steps:
     - script:
-      name: install ruby
-      code: |
-        rvm get latest
-        rvm reload
-        rvm install ruby-2.2.5
-        rvm --default use 2.2.5
-        gem install bundler
+        name: install ruby
+        code: |
+          rvm get latest
+          rvm reload
+          rvm install ruby-2.2.5
+          rvm --default use 2.2.5
+          gem install bundler
     - bundle-install
     - script:
         name: echo ruby information
         code: |
           echo "RUBY version $(ruby --version) running"
           echo "FROM location $(which ruby)"
-        echo -p "Gem list: $(gem list)"
+          echo -p "Gem list: $(gem list)"
     - script:
         name: rspec
         code: bundle exec rspec

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,21 +1,21 @@
 box: wercker/rvm
 build:
   steps:
-    - script:
-      name: install ruby
-      code: |
-        rvm get latest
-        rvm reload
-        rvm install ruby-2.2.5
-        rvm --default use 2.2.5
-        gem install bundler
-    - bundle-install
-    - script:
-        name: echo ruby information
+      - script:
+        name: install ruby
         code: |
-          echo "RUBY version $(ruby --version) running"
-          echo "FROM location $(which ruby)"
-        echo -p "Gem list: $(gem list)"
-    - script:
-        name: rspec
-        code: bundle exec rspec
+          rvm get latest
+          rvm reload
+          rvm install ruby-2.2.5
+          rvm --default use 2.2.5
+          gem install bundler
+      - bundle-install
+      - script:
+          name: echo ruby information
+          code: |
+            echo "RUBY version $(ruby --version) running"
+            echo "FROM location $(which ruby)"
+          echo -p "Gem list: $(gem list)"
+      - script:
+          name: rspec
+          code: bundle exec rspec

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,14 @@
-box: nafu/ubuntu12.04-ruby2.1.1@1.0.1
+box: wercker/rvm
 build:
   steps:
+    - script:
+      name: install ruby
+      code: |
+        rvm get latest
+        rvm reload
+        rvm install ruby-2.2.5
+        rvm --default use 2.2.5
+        gem install bundler
     - bundle-install
     - script:
         name: echo ruby information

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,21 +1,21 @@
 box: wercker/rvm
 build:
   steps:
-      - script:
-        name: install ruby
+    - script:
+      name: install ruby
+      code: |
+        rvm get latest
+        rvm reload
+        rvm install ruby-2.2.5
+        rvm --default use 2.2.5
+        gem install bundler
+    - bundle-install
+    - script:
+        name: echo ruby information
         code: |
-          rvm get latest
-          rvm reload
-          rvm install ruby-2.2.5
-          rvm --default use 2.2.5
-          gem install bundler
-      - bundle-install
-      - script:
-          name: echo ruby information
-          code: |
-            echo "RUBY version $(ruby --version) running"
-            echo "FROM location $(which ruby)"
-          echo -p "Gem list: $(gem list)"
-      - script:
-          name: rspec
-          code: bundle exec rspec
+          echo "RUBY version $(ruby --version) running"
+          echo "FROM location $(which ruby)"
+        echo -p "Gem list: $(gem list)"
+    - script:
+        name: rspec
+        code: bundle exec rspec


### PR DESCRIPTION
Fix `wercker` box image that needs ruby `~> 2.2`. Now we need this new box because of indirect dependency of `guard` gem (`listen` -> `ruby_dep`).
