### PR TITLE
Adds ability to use `private_key` and to sign URI for premium users

### DIFF
--- a/lib/google/directions.rb
+++ b/lib/google/directions.rb
@@ -16,6 +16,7 @@ module Google
 
     autoload :Config  , 'google/directions/config'
     autoload :Error   , 'google/directions/error'
+    autoload :Encoder , 'google/directions/encoder'
     autoload :Request , 'google/directions/request'
     autoload :Version , 'google/directions/version'
   end

--- a/lib/google/directions/config.rb
+++ b/lib/google/directions/config.rb
@@ -3,7 +3,8 @@ module Google
     class Config
       include Singleton
 
-      attr_accessor :client_id, :private_key, :timeout, :connect_timeout
+      attr_accessor :client_id, :private_key, :sign,
+                    :timeout, :connect_timeout
 
       def timeout
         @timeout || 10
@@ -11,6 +12,10 @@ module Google
 
       def connect_timeout
         @connect_timeout || 5
+      end
+
+      def sign
+        @sign || false
       end
     end
   end

--- a/lib/google/directions/encoder.rb
+++ b/lib/google/directions/encoder.rb
@@ -1,0 +1,23 @@
+require 'base64'
+require 'digest/sha1'
+
+module Google
+  module Directions
+    class Encoder
+      attr_reader :uri_with_params, :private_key
+
+      def initialize(uri_with_params, private_key)
+        @uri_with_params = uri_with_params
+        @private_key = private_key
+      end
+
+      def encode
+        binary_key = Base64.decode64(private_key.tr('-_','+/'))
+        signature = Digest::SHA1.base64digest(binary_key + uri_with_params)
+        signature = Base64.encode64(signature.tr('+/','-_')).tr("\n", '')
+
+        "#{uri_with_params}&signature=#{signature}"
+      end
+    end
+  end
+end

--- a/lib/google/directions/encoder.rb
+++ b/lib/google/directions/encoder.rb
@@ -13,7 +13,8 @@ module Google
 
       def encode
         binary_key = Base64.decode64(private_key.tr('-_','+/'))
-        signature = Digest::SHA1.base64digest(binary_key + uri_with_params)
+        digest = OpenSSL::Digest.new('sha1')
+        signature  = OpenSSL::HMAC.digest(digest, binary_key, uri_with_params)
         signature = Base64.encode64(signature.tr('+/','-_')).tr("\n", '')
 
         "#{uri_with_params}&signature=#{signature}"

--- a/lib/google/directions/request.rb
+++ b/lib/google/directions/request.rb
@@ -9,14 +9,16 @@ module Google
       attr_reader :params, :response
 
       def initialize
-        session.base_url        = (private_key ? 'https://' : 'http://') + BASE_URL
+        session.base_url        = ((sign? || private_key) ? 'https://' : 'http://') + BASE_URL
         session.timeout         = Google::Directions.config.timeout
         session.connect_timeout = Google::Directions.config.connect_timeout
       end
 
       def get(params)
         @params   = params.with_indifferent_access
-        @response = session.get GET_PATH + '?' + parse_params.to_query
+
+        url = sign_url_if_needed(GET_PATH + '?' + parse_params.to_query)
+        @response = session.get url
 
         response ? ::JSON.parse(response.body) : nil
       end
@@ -38,6 +40,10 @@ module Google
         parsed_params
       end
 
+      def sign_url_if_needed(uri_with_params)
+        sign? ? Encoder.new(uri_with_params, private_key).encode : uri_with_params
+      end
+
       def parse_waypoints
         optimize = !!params[:optimize] || false
         waypoints = params[:waypoints].join('|')
@@ -46,7 +52,14 @@ module Google
       end
 
       def set_auth_params!(parsed_params)
-        parsed_params[:key] = private_key if private_key
+        if sign?
+          missing('client_id') unless client_id
+          missing('private_key') unless private_key
+
+          parsed_params[:client] = client_id
+        elsif private_key
+          parsed_params[:key] = private_key
+        end
       end
 
       def session
@@ -59,6 +72,14 @@ module Google
 
       def private_key
         Google::Directions.config.private_key
+      end
+
+      def client_id
+        Google::Directions.config.client_id
+      end
+
+      def sign?
+        Google::Directions.config.sign
       end
     end
   end

--- a/spec/google/directions/encoder_spec.rb
+++ b/spec/google/directions/encoder_spec.rb
@@ -2,14 +2,13 @@ require 'spec_helper'
 
 describe Google::Directions::Encoder do
   describe '#encode' do
-
     let(:uri_with_params) { '/maps/api/geocode/json?address=Florianopolis&client=123' }
     let(:private_key) { 'vNIXE0xscrmjlyV-12Nj_BvUPaw=' }
 
     subject { described_class.new(uri_with_params, private_key).encode }
 
     it 'creates signature from path and query' do
-      expect(subject).to eq("#{uri_with_params}&signature=NUtYTGR0ckF4TWZ4Vnp4ZUI0WDZTcG8tekI0PQ==")
+      expect(subject).to eq("#{uri_with_params}&signature=VqUOoDBw//HLG5g76wWQLSg0/mw=")
     end
   end
 end

--- a/spec/google/directions/encoder_spec.rb
+++ b/spec/google/directions/encoder_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Google::Directions::Encoder do
+  describe '#encode' do
+
+    let(:uri_with_params) { '/maps/api/geocode/json?address=Florianopolis&client=123' }
+    let(:private_key) { 'vNIXE0xscrmjlyV-12Nj_BvUPaw=' }
+
+    subject { described_class.new(uri_with_params, private_key).encode }
+
+    it 'creates signature from path and query' do
+      expect(subject).to eq("#{uri_with_params}&signature=NUtYTGR0ckF4TWZ4Vnp4ZUI0WDZTcG8tekI0PQ==")
+    end
+  end
+end

--- a/spec/google/directions/request_spec.rb
+++ b/spec/google/directions/request_spec.rb
@@ -17,6 +17,21 @@ describe Google::Directions::Request do
       end
     end
 
+    context 'when private key is set' do
+      let(:url_with_key) { /^\S+key=\S+$/ }
+
+      before do
+        allow(Google::Directions.config).to receive(:private_key).and_return('MY_PRIVATE_KEY')
+      end
+
+      it 'should use key over HTTPS in request' do
+        expect_any_instance_of(Patron::Session).to receive(:base_url=).with(/https/)
+        expect_any_instance_of(Patron::Session).to receive(:get).with(url_with_key).once
+
+        subject.get(params)
+      end
+    end
+
     context 'when origin is missing' do
       let(:params) { { destination: 'Rua Frei Galvão, 69, São Paulo' } }
 

--- a/spec/google/directions/request_spec.rb
+++ b/spec/google/directions/request_spec.rb
@@ -32,6 +32,46 @@ describe Google::Directions::Request do
       end
     end
 
+    context 'when is set to sign request' do
+      let(:client_id) { 'my_client_id' }
+      let(:private_key) { 'vNIXE0xscrmjlyV-12Nj_BvUPaw=' }
+      let(:url_with_key) { /^\S+client=\S+\&signature=\S+$/ }
+
+      before do
+        allow(Google::Directions.config).to receive(:sign).and_return(true)
+      end
+
+      context 'when client_id and private_key are present' do
+        before do
+          allow(Google::Directions.config).to receive(:client_id).and_return(client_id)
+          allow(Google::Directions.config).to receive(:private_key).and_return(private_key)
+        end
+
+        it 'should add signature to query string over HTTPS' do
+          expect_any_instance_of(Patron::Session).to receive(:base_url=).with(/https/)
+          expect_any_instance_of(Patron::Session).to receive(:get).with(url_with_key).once
+
+          subject.get(params)
+        end
+      end
+
+      context 'when client_id is missing' do
+        it 'should raise an exception' do
+          expect{subject.get(params)}.to raise_error Google::Directions::Error, 'Missing parameter: client_id'
+        end
+      end
+
+      context 'when private_key is missing' do
+        before do
+          allow(Google::Directions.config).to receive(:client_id).and_return(client_id)
+        end
+
+        it 'should raise an exception' do
+          expect{subject.get(params)}.to raise_error Google::Directions::Error, 'Missing parameter: private_key'
+        end
+      end
+    end
+
     context 'when origin is missing' do
       let(:params) { { destination: 'Rua Frei Galvão, 69, São Paulo' } }
 


### PR DESCRIPTION
- [x] Use `private_key` under `HTTPS` if present
- [x] Sign with `private_key` if `sign` configuration is turned on

This PR will enable client request data from Google Maps API using `private_key` or signed (encrypted signature) with `client_id` and `private_key`.

Also tried to test `scheme` (protocol) and `path` of URL without relying in `Patron` implementation, but didn't get an idea to dodge of this. Any suggestion would be great.

:green_heart: tests! :)

---
### Details about URI signature

The steps followed to `sign` URI:

Construct the request URL without the signature, making sure to include your client parameter. Note that any non-standard characters will need to be URL-encoded:

```
https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&client=clientID
```

Strip off the domain portion of the request, leaving only the path and the query:

```
/maps/api/directions/json?origin=Toronto&destination=Montreal&client=clientID
```

Retrieve your private key, which is encoded in a modified Base64 for URLs, and sign the URL above using the HMAC-SHA1 algorithm. You may need to decode this key into its original binary format. Note that in most cryptographic libraries, the resulting signature will be in binary format.

**Note:** Modified Base64 for URLs replaces the + and / characters of standard Base64 with - and _ respectively, so that these Base64 signatures no longer need to be URL-encoded.

Encode the resulting binary signature using the modified Base64 for URLs to convert this signature into something that can be passed within a URL.
Attach this signature to the URL within a signature parameter:

```
https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&client=clientID&signature=base64signature
```

Source: [Google Maps API Documentation](https://developers.google.com/maps/documentation/directions/get-api-key)
