### PR TITLE
Fix Patron scope context in Request

### DIFF
--- a/lib/google/directions/request.rb
+++ b/lib/google/directions/request.rb
@@ -1,3 +1,5 @@
+require 'patron'
+
 module Google
   module Directions
     class Request
@@ -63,7 +65,7 @@ module Google
       end
 
       def session
-        @session ||= Patron::Session.new
+        @session ||= ::Patron::Session.new
       end
 
       def missing(name)


### PR DESCRIPTION
When using gem, `Patron::Session` is scoped to `Google::Directions` module. This sets its namespace to root and also `require 'patron'` to make it available when using gem.
