### PR TITLE
Fix clean up before `Base64.encode64` 

### DIFF
--- a/lib/google/directions/encoder.rb
+++ b/lib/google/directions/encoder.rb
@@ -15,7 +15,7 @@ module Google
         binary_key = Base64.decode64(private_key.tr('-_','+/'))
         digest = OpenSSL::Digest.new('sha1')
         signature  = OpenSSL::HMAC.digest(digest, binary_key, uri_with_params)
-        signature = Base64.encode64(signature.tr('+/','-_')).tr("\n", '')
+        signature = Base64.encode64(signature).tr('+/','-_').tr("\n", '')
 
         "#{uri_with_params}&signature=#{signature}"
       end

--- a/spec/google/directions/encoder_spec.rb
+++ b/spec/google/directions/encoder_spec.rb
@@ -8,7 +8,7 @@ describe Google::Directions::Encoder do
     subject { described_class.new(uri_with_params, private_key).encode }
 
     it 'creates signature from path and query' do
-      expect(subject).to eq("#{uri_with_params}&signature=VqUOoDBw//HLG5g76wWQLSg0/mw=")
+      expect(subject).to eq("#{uri_with_params}&signature=VqUOoDBw__HLG5g76wWQLSg0_mw=")
     end
   end
 end


### PR DESCRIPTION
Before I was cleaning it before `encode`, generating a different hash of Google API Documentation example.
